### PR TITLE
radiocut: Update User-Agent version in headers

### DIFF
--- a/radiocut/__init__.py
+++ b/radiocut/__init__.py
@@ -36,7 +36,7 @@ Examples:
 """
 
 HEADERS = {
-    'User-Agent': 'Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:54.0) Gecko/20100101 Firefox/54.0',
+    'User-Agent': 'Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:62.0) Gecko/20100101 Firefox/62.0',
 }
 
 def get_audiocut(url, verbose=False, duration=None):


### PR DESCRIPTION
The User-Agent version is a little bit old, so the server returns an
Error 503 response. Fix this updating the version used.

This fixes issue https://github.com/mgaitan/radiocut_downloader/issues/13